### PR TITLE
Run lint action on every PR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,7 @@ name: lint
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
-on:
-  pull_request:
-    paths:
-      - src/**/*
-      - yarn.lock
-      - package.json
+on: pull_request
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Otherwise I can't merge PR's not related to src directory.
Further we're going to remove action, because we lint codebase via gitlab CI.