### PR TITLE
added action to tag client's PRs

### DIFF
--- a/.github/workflows/tag-client-pr.yml
+++ b/.github/workflows/tag-client-pr.yml
@@ -1,0 +1,19 @@
+name: Label Client PRs
+
+on:
+  pull_request:
+    paths: 
+    - 'client/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR
+        run: gh pr edit $PR_NUMBER --add-label $LABEL_NAME
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          LABEL_NAME: "client"


### PR DESCRIPTION
Added GitHub action to add a label to any Pull Request that modifies files inside the client directory.

This label is used to separate the class of pull requests and to organize them better.