### PR TITLE
Update copy for Rococo faucet

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -6,7 +6,7 @@ Web Client to access the faucet. Powered by Catpcha v2
 
 The objective of this project is to simplify the use of the Faucet through a standalone webpage and open ability to share it via social networks & google search.
 
-Two current options are to [access Matrix and contact a bot](https://wiki.polkadot.network/docs/learn-DOT#getting-tokens-on-the-rococo-testnet) or [Ink! documentation](https://use.ink/faucet).
+Two current options are to [access Matrix and contact a bot](https://wiki.polkadot.network/docs/learn-DOT#getting-tokens-on-the-rococo-testnet) or [ink! documentation](https://use.ink/faucet).
 
 ## Development
 
@@ -15,7 +15,7 @@ To develop you need two env variables:
 - `PUBLIC_CAPTCHA_KEY`: The [reCaptcha v2 site key](https://www.google.com/u/0/recaptcha/admin).
 - `PUBLIC_FAUCET_URL`: The endpoint to contact the faucet.
 
-The reason for which these variables have `PUBLIC_` as a prefix is a security meassure to not upload any unnecesary data. [More info here](https://kit.svelte.dev/docs/modules#$env-static-public)
+The reason for which these variables have `PUBLIC_` as a prefix is a security measure to not upload any unnecessary data. [More info here](https://kit.svelte.dev/docs/modules#$env-static-public)
 
 If you wish to only interact with the flow but do not wish to contact the faucet, you can set the following env variable to true `PUBLIC_DEMO_MODE`.
 This will show that the application is running on Demo mode and will not contact the faucet but simulate the flow.
@@ -28,14 +28,14 @@ This will show that the application is running on Demo mode and will not contact
 
 ### Build static site
 
-If you wish to build the site as a static site, when building add the enviroment variable `STATIC=true`. This will disable any kind of server side rendering
-and will prerender all the content. You won't be able to dynamically load enviroment variables if you do this.
+If you wish to build the site as a static site, when building add the environment variable `STATIC=true`. This will disable any kind of server side rendering
+and will pre-render all the content. You won't be able to dynamically load environment variables if you do this.
 
 ## Deployment
 
 [![GitHub Pages deploy](https://github.com/paritytech/polkadot-testnet-faucet/actions/workflows/deploy-site.yml/badge.svg?event=push)](https://github.com/paritytech/polkadot-testnet-faucet/actions/workflows/deploy-site.yml)
 
-We have a GitHub action that evaulates and builds the website, deploying it to GitHub Pages.
+We have a GitHub action that evaluates and builds the website, deploying it to GitHub Pages.
 
 ## Setting a default parachain
 

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -24,17 +24,7 @@
 			<Form network={parachain ?? -1} />
 		</Card>
 	</div>
-
-	<p class="read-the-docs">
-		Check out <a href="https://use.ink/" target="_blank" rel="noreferrer">Ink!</a>, the official
-		Substrate documentation!
-	</p>
 </main>
-
-<style>
-	.read-the-docs {
-		color: #888;
-	}
 
 	main {
 		max-width: 1280px;

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -26,6 +26,7 @@
 	</div>
 </main>
 
+<style>
 	main {
 		max-width: 1280px;
 		margin: 0 auto;


### PR DESCRIPTION
This PR updates some copy around the Rococo faucet and removes the mention of ink! docs on the rendered page. It may be useful to link to some more relevant documentation about using Rococo in a future PR once the page gets some design love.