### PR TITLE
clarified name of the relay chain in Rococo

### DIFF
--- a/client/src/lib/utils/networkData.ts
+++ b/client/src/lib/utils/networkData.ts
@@ -14,7 +14,7 @@ export const Rococo: NetworkData = {
 	networkName: "Rococo",
 	currency: "$ROC",
 	chains: [
-		{ name: "Relay Chain", id: -1 },
+		{ name: "Rococo Relay Chain", id: -1 },
 		{ name: "Rockmine", id: 1000 },
 		{ name: "Contracts", id: 1002 },
 		{ name: "Encointer Lietaer", id: 1003 },


### PR DESCRIPTION
Renamed the `Relay Chain` to `Rococo Relay Chain` to make it even more obvious for newcomers.