### PR TITLE
fixed relative path usage on base enabled

### DIFF
--- a/client/svelte.config.js
+++ b/client/svelte.config.js
@@ -13,7 +13,10 @@ const config = {
 
 	kit: {
 		adapter: process.env.STATIC ? staticAdapter() : nodeAdapter(),
-		paths: { base: process.env.BASE ?? "" }
+		paths: {
+			base: process.env.BASE ?? "",
+			relative: !process.env.BASE
+		}
 	}
 };
 


### PR DESCRIPTION
Fixed missing configuration that would enable relative path when the base is enabled.

With the previous configuration it was looking for files at `./polkadot-testnet-faucet` (so, when you are in `/polkadot-testnet-faucet` it will search for files in `/polkadot-testnet-faucet/polkadot-testnet-faucet`.

This setting disables relatives path when the variable `BASE` is enabled.