### PR TITLE
question btn hidden on mobile

### DIFF
--- a/client/src/lib/components/NavBar.svelte
+++ b/client/src/lib/components/NavBar.svelte
@@ -33,7 +33,7 @@
 
 <style lang="postcss">
 	.questions-btn {
-		@apply btn text-white hover:text-opacity-70;
+		@apply btn text-white hover:text-opacity-70 hidden md:inline-flex;
 		background-color: #191924;
 		border: 1px solid rgba(255, 255, 255, 0.2);
 		/* button/none */


### PR DESCRIPTION
Made the "Questions" button hide in mobile. This is because too many buttons in the UI sometimes overflow the width on the screen.

In my phone which has a small screen I could see the screen overflowing.

With the btn:
<img src="https://github.com/paritytech/polkadot-testnet-faucet/assets/8524599/b2cb794c-b295-4e58-85e4-1e85403c06e5" width="400" height="400" />

Without the btn:
<img src="https://github.com/paritytech/polkadot-testnet-faucet/assets/8524599/52cbf3b5-1a5b-4de1-b5a1-5f4228d7bc9f" width="400" height="400" />

