### PR TITLE
Fixed block explorer 🧱 url in success screen

### DIFF
--- a/client/src/lib/components/Faucet.svelte
+++ b/client/src/lib/components/Faucet.svelte
@@ -5,10 +5,10 @@
 	import Error from "$lib/components/screens/Error.svelte";
 	import FrequentlyAskedQuestions from "$lib/components/screens/FrequentlyAskedQuestions.svelte";
 	import Success from "$lib/components/screens/Success.svelte";
+	import type { NetworkData } from "$lib/utils/networkData";
 	import { operation, testnet } from "$lib/utils/stores";
 	import { onMount } from "svelte";
 	import { fly } from "svelte/transition";
-	import type { NetworkData } from "$lib/utils/networkData";
 
 	export let faq: string;
 	export let network: NetworkData;
@@ -26,7 +26,7 @@
 
 <main>
 	<SocialTags />
-	<div class="flex items-center justify-center my-16">
+	<div class="flex items-center justify-center mt-16 mb-4 md:my-16">
 		<Card>
 			{#if !$operation}
 				<Form network={parachain ?? -1} />

--- a/client/src/lib/components/Form.svelte
+++ b/client/src/lib/components/Form.svelte
@@ -61,33 +61,7 @@
 			Get some {$testnet.currency}
 		</button>
 	{:else}
-		{#await webRequest}
-			<button class="btn btn-primary loading" disabled> Loading</button>
-		{:then result}
-			<div in:fly={{ y: 30, duration: 500 }} class="alert alert-success shadow-lg">
-				<div>
-					<Tick />
-					<span class="text-left">
-						Your funds have been sent.<br />
-						<a
-							href={`${$testnet.explorer}/extrinsic/${result}`}
-							target="_blank"
-							rel="noreferrer"
-							class="link link-neutral"
-						>
-							Click here to see the transaction
-						</a>
-					</span>
-				</div>
-			</div>
-		{:catch error}
-			<div class="alert alert-error shadow-lg" data-testid="error">
-				<div>
-					<Cross />
-					<span class="text-left">{error}</span>
-				</div>
-			</div>
-		{/await}
+		<button class="btn btn-primary loading" disabled> Loading</button>
 	{/if}
 </form>
 

--- a/client/src/lib/components/Form.svelte
+++ b/client/src/lib/components/Form.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
 	import { PUBLIC_CAPTCHA_KEY } from "$env/static/public";
 	import { operation, testnet } from "$lib/utils/stores";
-	import { fly } from "svelte/transition";
 	import { request as faucetRequest } from "../utils";
 	import CaptchaV2 from "./CaptchaV2.svelte";
 	import NetworkInput from "./NetworkInput.svelte";
-	import Cross from "./icons/Cross.svelte";
-	import Tick from "./icons/Tick.svelte";
 
 	let address: string = "";
 	export let network: number = -1;

--- a/client/src/lib/components/screens/FrequentlyAskedQuestions.svelte
+++ b/client/src/lib/components/screens/FrequentlyAskedQuestions.svelte
@@ -3,8 +3,8 @@
 	export let faq: string;
 </script>
 
-<div class="flex items-center justify-center my-16">
-	<div class="card md:w-2/4 w-5/6 min-w-full mt-12 md:mt-20">
+<div class="flex items-center justify-center my-2 md:my-16">
+	<div class="card md:w-2/4 w-5/6 min-w-full mt-2 md:mt-20">
 		<div class="card-body items-center text-center">
 			<h1 id="faq">Frequently Asked Questions</h1>
 			<div

--- a/client/src/lib/components/screens/Success.svelte
+++ b/client/src/lib/components/screens/Success.svelte
@@ -12,7 +12,7 @@
 	Successfully sent {$testnet.currency} to your address.
 </div>
 <a
-	href={`https://rococo.subscan.io/extrinsic/${hash}`}
+	href={`${$testnet.explorer}/extrinsic/${hash}`}
 	data-testid="success-button"
 	target="_blank"
 	rel="noreferrer"


### PR DESCRIPTION
Updated the success screen to use the url from the block explorer instead of a hardcoded one.

This commit closes #293 

Deleted residual code from before the existence of the success and failure screens.

Also, modified margins on mobile so the FAQ section isn't that far away and you don't need to scroll that much.
