### PR TITLE
Update the E2E tests to run against Polkadot v0.9.42

### DIFF
--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - rzadp/e2e-update
 jobs:
   e2e:
     timeout-minutes: 15

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -19,8 +19,8 @@ jobs:
       - run: yarn install --network-concurrency 1 --frozen-lockfile
       - name: Download Polkadot and parachain binaries
         run: |
-          wget --no-verbose https://github.com/paritytech/cumulus/releases/download/v0.9.380/polkadot-parachain
-          wget --no-verbose https://github.com/paritytech/polkadot/releases/download/v0.9.38/polkadot
+          wget --no-verbose https://github.com/paritytech/cumulus/releases/download/v0.9.420/polkadot-parachain
+          wget --no-verbose https://github.com/paritytech/polkadot/releases/download/v0.9.42/polkadot
           chmod +x ./polkadot*
         working-directory: e2e
       - name: Run a local relaychain with a parachain using zombienet

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - rzadp/e2e-update
 jobs:
   e2e:
     timeout-minutes: 15

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -96,11 +96,11 @@ and by asserting that it responds to RPC requests:
 
 ```bash
 # Relay chain
-curl localhost:9933                              
+curl localhost:9933
 # Expecting: Used HTTP Method is not allowed. POST or OPTIONS is required
 
 # Parachain
-curl localhost:9934 
+curl localhost:9934
 # Expecting: Used HTTP Method is not allowed. POST or OPTIONS is required
 ```
 


### PR DESCRIPTION
Attempting to reproduce https://github.com/paritytech/polkadot-testnet-faucet/issues/286 (without luck).