### PR TITLE
Trappist faucet + updates

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -31,8 +31,6 @@ jobs:
       - run: yarn run build
         env:
           PUBLIC_CAPTCHA_KEY: 6LdU5kckAAAAANktvvAKJ0auYUBRP0su94G7WXwe
-          PUBLIC_FAUCET_ROCOCO_URL: https://rococo-faucet.parity-testnet.parity.io/drip/web
-          PUBLIC_FAUCET_WESTEND_URL: "https://westend-faucet.polkadot.io/drip/web"
           GITHUB_PAGES: "/${{ github.event.repository.name }}"
           STATIC: true
           BASE: "/polkadot-testnet-faucet"

--- a/client/.env
+++ b/client/.env
@@ -1,6 +1,9 @@
 PUBLIC_DEMO_MODE=
 PUBLIC_CAPTCHA_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
-PUBLIC_FAUCET_ROCOCO_URL=
-PUBLIC_FAUCET_WESTEND_URL=
+
+PUBLIC_FAUCET_URL=
+# uncomment to direct requests to local instance
+# PUBLIC_FAUCET_URL=http://localhost:5555
+
 PUBLIC_ISSUE_LINK=https://github.com/paritytech/polkadot-testnet-faucet/issues/new/choose
 PUBLIC_FORUM="https://forum.polkadot.network/t/experiencing-trouble-accessing-our-rococo-faucet-please-post-here/2952"

--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -10,6 +10,4 @@ conf.overrides.push(tsConfOverride);
 // and it doesn't live well with Tailwind CSSª
 conf.rules["svelte/valid-compile"] = ["error", { ignoreWarnings: true }];
 
-conf.rules["no-restricted-imports"] = "off";
-
 module.exports = conf;

--- a/client/README.md
+++ b/client/README.md
@@ -13,7 +13,7 @@ Two current options are to [access Matrix and contact a bot](https://wiki.polkad
 To develop you need two env variables:
 
 - `PUBLIC_CAPTCHA_KEY`: The [reCaptcha v2 site key](https://www.google.com/u/0/recaptcha/admin).
-- `PUBLIC_FAUCET_URL`: The endpoint to contact the faucet.
+- `PUBLIC_FAUCET_URL`: The endpoint to contact the faucet backend. Keep unset to run client-side code with production backend.
 
 The reason for which these variables have `PUBLIC_` as a prefix is a security measure to not upload any unnecessary data. [More info here](https://kit.svelte.dev/docs/modules#$env-static-public)
 

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -6,9 +6,8 @@ const config: PlaywrightTestConfig = {
     port: 4173,
     env: {
       PUBLIC_CAPTCHA_KEY: "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI",
-      PUBLIC_FAUCET_WESTEND_URL: "https://example.com/test",
-      PUBLIC_FAUCET_ROCOCO_URL: "https://test.com/example",
       PUBLIC_DEMO_MODE: "",
+      PUBLIC_FAUCET_URL: "https://example.com/test",
     },
   },
   testDir: "tests",

--- a/client/src/lib/components/Form.svelte
+++ b/client/src/lib/components/Form.svelte
@@ -55,7 +55,7 @@
       <CaptchaV2 captchaKey={PUBLIC_CAPTCHA_KEY ?? ""} on:token={onToken} theme="dark" />
     </div>
     <button class="submit-btn" type="submit" data-testid="submit-button" disabled={!formValid}>
-      Get some {$testnet.currency}
+      Get some {$testnet.currency}s
     </button>
   {:else}
     <button class="btn btn-primary loading" disabled> Loading</button>

--- a/client/src/lib/components/screens/Success.svelte
+++ b/client/src/lib/components/screens/Success.svelte
@@ -9,11 +9,13 @@
   <CheckCircle />
 </div>
 <div class="message">
-  Successfully sent {$testnet.currency} to your address.
+  Successfully sent {$testnet.currency}s to your address.
 </div>
-<a href={`${$testnet.explorer}/extrinsic/${hash}`} data-testid="success-button" target="_blank" rel="noreferrer">
-  <button class="submit-btn"> See transaction details </button>
-</a>
+{#if $testnet.explorer}
+  <a href={`${$testnet.explorer}/extrinsic/${hash}`} data-testid="success-button" target="_blank" rel="noreferrer">
+    <button class="submit-btn"> See transaction details</button>
+  </a>
+{/if}
 
 <style lang="postcss">
   .message {

--- a/client/src/lib/utils/networkData.ts
+++ b/client/src/lib/utils/networkData.ts
@@ -1,9 +1,17 @@
 import { base } from "$app/paths";
-import { PUBLIC_FAUCET_ROCOCO_URL, PUBLIC_FAUCET_WESTEND_URL } from "$env/static/public";
+import { PUBLIC_FAUCET_URL } from "$env/static/public";
 
 export interface ChainData {
   name: string;
   id: number;
+}
+
+function faucetUrl(defaultUrl: string): string {
+  if (PUBLIC_FAUCET_URL !== "") {
+    return PUBLIC_FAUCET_URL;
+  }
+
+  return defaultUrl;
 }
 
 export interface NetworkData {
@@ -11,12 +19,12 @@ export interface NetworkData {
   currency: string;
   chains: ChainData[];
   endpoint: string;
-  explorer: string;
+  explorer: string | null;
 }
 
 export const Rococo: NetworkData = {
   networkName: "Rococo",
-  currency: "$ROC",
+  currency: "ROC",
   chains: [
     { name: "Rococo Relay Chain", id: -1 },
     { name: "Rockmine", id: 1000 },
@@ -24,25 +32,34 @@ export const Rococo: NetworkData = {
     { name: "Encointer Lietaer", id: 1003 },
     { name: "Bridgehub", id: 1013 },
   ],
-  endpoint: PUBLIC_FAUCET_ROCOCO_URL as string,
+  endpoint: faucetUrl("https://rococo-faucet.parity-testnet.parity.io/drip/web"),
   explorer: "https://rococo.subscan.io",
 };
 
 export const Westend: NetworkData = {
   networkName: "Westend",
-  currency: "$WND",
+  currency: "WND",
   chains: [
     { name: "Westend Relay Chain", id: -1 },
     { name: "Westmint", id: 1000 },
     { name: "Collectives", id: 1001 },
   ],
-  endpoint: PUBLIC_FAUCET_WESTEND_URL as string,
+  endpoint: faucetUrl("https://westend-faucet.polkadot.io/drip/web"),
   explorer: "https://westend.subscan.io",
+};
+
+export const Trappist: NetworkData = {
+  networkName: "Trappist",
+  currency: "HOP",
+  chains: [{ name: "Trappist rococo parachain", id: -1 }],
+  endpoint: faucetUrl("https://trappist-faucet.polkadot.io/drip/web"),
+  explorer: null,
 };
 
 export const Networks: { network: NetworkData; url: string }[] = [
   { network: Rococo, url: (base as string) || "/" },
   { network: Westend, url: `${base as string}/westend` },
+  { network: Trappist, url: `${base as string}/trappist` },
 ];
 
 export function getChainName(network: NetworkData, id: number): string | null {

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 
   let network: NetworkData = Rococo;
   let faq: string = faqMd
-    .replaceAll("<NETWORK-TOKEN>", network.currency.replace("$", ""))
+    .replaceAll("<NETWORK-TOKEN>", network.currency)
     .replaceAll("<NETWORK-NAME>", network.networkName);
 </script>
 

--- a/client/src/routes/trappist/+page.svelte
+++ b/client/src/routes/trappist/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import Faucet from "$lib/components/Faucet.svelte";
-  import { Westend, type NetworkData } from "$lib/utils/networkData";
+  import { Trappist, type NetworkData } from "$lib/utils/networkData";
   import faqMd from "$lib/assets/FAQ.md?raw";
 
-  let network: NetworkData = Westend;
+  let network: NetworkData = Trappist;
   let faq: string = faqMd
     .replaceAll("<NETWORK-TOKEN>", network.currency)
     .replaceAll("<NETWORK-NAME>", network.networkName);

--- a/client/tests/rococo.test.ts
+++ b/client/tests/rococo.test.ts
@@ -8,5 +8,5 @@ const chains = [
   { name: "Bridgehub", id: 1013 },
 ];
 
-const test = new FaucetTests("/", "PUBLIC_FAUCET_ROCOCO_URL", "Rococo Faucet", chains);
-test.runTests();
+const tests = new FaucetTests({ faucetName: "Rococo Faucet", chains, url: "/", expectTransactionLink: true });
+tests.runTests();

--- a/client/tests/trappist.test.ts
+++ b/client/tests/trappist.test.ts
@@ -1,0 +1,11 @@
+import { FaucetTests } from "./faucet.js";
+
+const chains = [{ name: "Trappist Parachain", id: -1 }];
+
+const tests = new FaucetTests({
+  faucetName: "Trappist Faucet",
+  chains,
+  url: "/trappist",
+  expectTransactionLink: false,
+});
+tests.runTests();

--- a/client/tests/westend.test.ts
+++ b/client/tests/westend.test.ts
@@ -6,5 +6,5 @@ const chains = [
   { name: "Collectives", id: 1001 },
 ];
 
-const tests = new FaucetTests("/westend", "PUBLIC_FAUCET_WESTEND_URL", "Westend Faucet", chains);
+const tests = new FaucetTests({ faucetName: "Westend Faucet", chains, url: "/westend", expectTransactionLink: true });
 tests.runTests();

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "sqlite3": "^5.1.2"
   },
   "devDependencies": {
-    "@eng-automation/js-style": "^2.1.0",
+    "@eng-automation/js-style": "^2.2.0",
     "@types/body-parser": "^1.19.2",
     "@types/express": "^4.17.13",
     "@types/jest": "^29.4.0",

--- a/src/networkData.ts
+++ b/src/networkData.ts
@@ -70,6 +70,17 @@ const versi: NetworkData = {
   rpcEndpoint: "wss://versi-rpc-node-0.parity-versi.parity.io/",
 };
 
+const trappist: NetworkData = {
+  balanceCap: 100,
+  chains: [],
+  currency: "HOP",
+  decimals: 12,
+  dripAmount: "10",
+  explorer: null,
+  networkName: "Trappist",
+  rpcEndpoint: "wss://rococo-trappist-rpc.polkadot.io/",
+};
+
 const e2e: NetworkData = {
   balanceCap: 100,
   chains: [],
@@ -81,7 +92,7 @@ const e2e: NetworkData = {
   rpcEndpoint: "ws://host.docker.internal:9933/",
 };
 
-export const networks: Record<string, NetworkData> = { rococo, versi, westend, wococo, e2e };
+export const networks: Record<string, NetworkData> = { rococo, versi, westend, wococo, e2e, trappist };
 
 export function getNetworkData(networkName: string): NetworkData {
   if (!Object.keys(networks).includes(networkName)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -497,10 +497,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eng-automation/js-style@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eng-automation/js-style/-/js-style-2.1.0.tgz#9f6b9ce911e65ef103ed03ed7c92dac06d5abe7f"
-  integrity sha512-jAMAE7SzIjVMNXkkNwuyJKEHcge47xXaIvg/z6K0pr9ImIp8ZcAoP/B5v58Zy5FOSyweNQISrnYVZjGfw7ZatQ==
+"@eng-automation/js-style@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@eng-automation/js-style/-/js-style-2.2.0.tgz#d7c21dd68e4f3b1886c522723e691866e206dd11"
+  integrity sha512-j1S6kRLkavv4X4azP8dIhiGTmHG/BkuOG01abVaJbAJJXsNYWyKFjoRQjywkBvF9i8sknDzql33iRr5jhArOYw==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^5.59.1"
     "@typescript-eslint/parser" "^5.59.1"


### PR DESCRIPTION
Stopped copying known static urls like PUBLIC_FAUCET_ROCOCO_URL, storing
it in NetworkData now.
Setting PUBLIC_FAUCET_URL to anything non-empty will override all
requests to it.

Trappist doesn't exist on subscan yet, so making it optional.
