### PR TITLE
Fix drip for networks with high decimals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,6 @@ SMF_CONFIG_MATRIX_SERVER=https://m.parity.io
 # To feed new account with test tokens, go to https://matrix.to/#/#westend_faucet:matrix.org and drip to new address
 # some convenient for tests amount "!drip <address> <amount>"
 SMF_CONFIG_FAUCET_ACCOUNT_MNEMONIC="this is a fake mnemonic"
-SMF_CONFIG_PORT=5555
 
 # Only used with external access
 SMF_CONFIG_RECAPTCHA_SECRET="6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe" # Public testing secret, will accept all tokens.

--- a/src/dripper/polkadot/PolkadotActions.ts
+++ b/src/dripper/polkadot/PolkadotActions.ts
@@ -87,7 +87,7 @@ export class PolkadotActions {
 
     return balanceFree
       .toBn()
-      .div(new BN(10 ** networkData.decimals))
+      .div((new BN(10).pow(new BN(networkData.decimals))))
       .toNumber();
   }
 

--- a/src/dripper/polkadot/PolkadotActions.ts
+++ b/src/dripper/polkadot/PolkadotActions.ts
@@ -87,7 +87,7 @@ export class PolkadotActions {
 
     return balanceFree
       .toBn()
-      .div((new BN(10).pow(new BN(networkData.decimals))))
+      .div(new BN(10).pow(new BN(networkData.decimals)))
       .toNumber();
   }
 


### PR DESCRIPTION
This PR fixes two things:
- For the `.env` that var appears two times
- For networks that have very high decimals that don't fit in a normal int64 the current approach doesn't work as it can't calculate 10 ** decimals. So we have to use BN as well to make that calculation