### PR TITLE
Updated actions to latest and added retention period

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -18,11 +18,11 @@ jobs:
         working-directory: client
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Install node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4.0.2
         with:
-          node-version: 18
+          node-version: 20
       - run: yarn install --frozen-lockfile
       - run: yarn run check
       - name: Install Playwright
@@ -33,11 +33,12 @@ jobs:
           PUBLIC_CAPTCHA_KEY: 6LcgFI4nAAAAAATrEMoJ6zBacsx5udc1UhGFXemH
           GITHUB_PAGES: "/${{ github.event.repository.name }}"
           STATIC: true
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4.3.1
         with:
           name: faucet
           path: ./client/build
           if-no-files-found: error
+          retention-days: 5
   deploy-to-github-pages:
     environment:
       name: github-pages
@@ -47,18 +48,18 @@ jobs:
     needs: [build-faucet]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Download page
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4.1.4
         with:
           name: faucet
           path: ./dist
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v4.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: ./dist
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
We currently don't have an artifact retention period, so it defaults to 90 days.

While the artifact for the site is not too big, having one build per push and PR can quickly accumulate the amount and make us hit our hard limit.

By adding a limit to the retention day of 5 days we ensure that we get rid of the old artifacts faster than waiting for two whole months.

I also updated all the actions version to latest release