### PR TITLE
Update Frequency Faucet URL

### DIFF
--- a/client/src/lib/components/NetworkDropdown.svelte
+++ b/client/src/lib/components/NetworkDropdown.svelte
@@ -25,7 +25,7 @@
       </li>
     {/each}
     <li>
-      <a href="https://faucet.rococo.frequency.xyz">Frequency</a>
+      <a href="https://faucet.testnet.frequency.xyz">Frequency</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
As the Frequency Faucet now also supports Frequency Paseo testnet in addition to the Rococo one, the url is being set to a generic one instead of specific for the network.

https://faucet.testnet.frequency.xyz/

<img width="688" alt="image" src="https://github.com/paritytech/polkadot-testnet-faucet/assets/1252199/97fbb24f-7903-4d9f-80b7-ee5e6f542d16">
