### PR TITLE
moved tag-client to work in pull_request_target

### DIFF
--- a/.github/workflows/tag-client-pr.yml
+++ b/.github/workflows/tag-client-pr.yml
@@ -1,7 +1,7 @@
 name: Label Client PRs
 
 on:
-  pull_request:
+  pull_request_target:
     paths: 
     - 'client/**'
 


### PR DESCRIPTION
It fails when an external contributors make a PR.

This will fix that issue.