### PR TITLE
Temporary add more memory

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
 dependencies:
   - name: substrate-faucet
     version: "3.0.3"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,10 +3,10 @@ substrate-faucet:
     team: opstooling
   resources:
     requests:
-      memory: 128Mi
+      memory: 512Mi
       cpu: 0.1
     limits:
-      memory: 512Mi
+      memory: 768Mi
   postgresql:
     primary:
       podLabels:


### PR DESCRIPTION
After recent PAPI upgrade, faucets started to get OOMs due to huge peak
in memory usage during startup.
While the issue is being worked on, adding more memory to survive it.
