### PR TITLE
Using fixUnorderedBlocks compat from papi

### DIFF
--- a/src/papi/client.ts
+++ b/src/papi/client.ts
@@ -2,6 +2,7 @@ import { config } from "#src/config";
 import fs from "fs";
 import { createClient, PolkadotClient } from "polkadot-api";
 import { withLogsRecorder } from "polkadot-api/logs-provider";
+import { fixUnorderedBlocks, parsed } from "polkadot-api/polkadot-sdk-compat";
 import { getWsProvider, JsonRpcProvider } from "polkadot-api/ws-provider/node";
 
 import { getNetworkData } from "./chains";
@@ -20,4 +21,4 @@ if (process.env.PAPI_DEBUG) {
   }, provider);
 }
 
-export const client: PolkadotClient = createClient(provider);
+export const client: PolkadotClient = createClient(parsed(fixUnorderedBlocks)(provider));


### PR DESCRIPTION
This should fix `TypeError: Cannot read properties of undefined (reading
'number')` crashes.
See https://github.com/polkadot-api/polkadot-api/issues/710

Related to #438, but isn't the only reason for crashes
