### PR TITLE
added support to `paseo` parachains ⛓️

### DIFF
--- a/.github/workflows/tag-client-pr.yml
+++ b/.github/workflows/tag-client-pr.yml
@@ -12,7 +12,7 @@ jobs:
   label-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Label PR
         run: gh pr edit $PR_NUMBER --add-label $LABEL_NAME
         env:

--- a/client/src/lib/utils/networkData.ts
+++ b/client/src/lib/utils/networkData.ts
@@ -55,7 +55,13 @@ export const Westend: NetworkData = {
 export const Paseo: NetworkData = {
   networkName: "Paseo",
   currency: "PAS",
-  chains: [{ name: "Paseo Relay", id: -1 }],
+  chains: [
+    { name: "Paseo Relay", id: -1 },
+    { name: "AssetHub", id: 1000 },
+    { name: "BridgeHub", id: 1002 },
+    { name: "People", id: 1004 },
+    { name: "Coretime", id: 1005 },
+  ],
   endpoint: faucetUrl("https://paseo-faucet.parity-testnet.parity.io/drip/web"),
   explorer: null,
 };

--- a/client/tests/paseo.test.ts
+++ b/client/tests/paseo.test.ts
@@ -3,9 +3,9 @@ import { FaucetTests } from "./faucet.js";
 const chains = [
   { name: "Paseo Relay", id: -1 },
   { name: "AssetHub", id: 1000 },
-  { name: "Collectives", id: 1001 },
   { name: "BridgeHub", id: 1002 },
   { name: "People", id: 1004 },
+  { name: "Coretime", id: 1005 },
 ];
 
 const tests = new FaucetTests({ faucetName: "Paseo Faucet", chains, url: "/", expectTransactionLink: false });

--- a/client/tests/paseo.test.ts
+++ b/client/tests/paseo.test.ts
@@ -1,6 +1,12 @@
 import { FaucetTests } from "./faucet.js";
 
-const chains = [{ name: "Paseo Relay", id: -1 }];
+const chains = [
+  { name: "Paseo Relay", id: -1 },
+  { name: "AssetHub", id: 1000 },
+  { name: "Collectives", id: 1001 },
+  { name: "BridgeHub", id: 1002 },
+  { name: "People", id: 1004 },
+];
 
 const tests = new FaucetTests({ faucetName: "Paseo Faucet", chains, url: "/", expectTransactionLink: false });
 tests.runTests();


### PR DESCRIPTION
Resolves #437

This pull request includes an update to the `Paseo` network data in the `networkData.ts` file to add several new chains.

Changes to network data:

* [`client/src/lib/utils/networkData.ts`](diffhunk://#diff-18208224988b15c7ed0e5e9f908827fea45f65edd128b85a8e2453b84e11dac2L58-R64): Added new chains `AssetHub`, `BridgeHub`, `People`, and `Coretime` to the `Paseo` network.