### PR TITLE
Decrease paseo drips

### DIFF
--- a/src/papi/chains/paseo.ts
+++ b/src/papi/chains/paseo.ts
@@ -14,11 +14,11 @@ import { signer } from "#src/papi/signer";
 import { PolkadotClient } from "polkadot-api";
 
 const networkData: NetworkData = {
-  balanceCap: 5500,
+  balanceCap: 600,
   chains: [],
   currency: "PAS",
   decimals: 10,
-  dripAmount: "5000",
+  dripAmount: "500",
   explorer: null,
   networkName: "Paseo",
   rpcEndpoint: "wss://sys.dotters.network/paseo",


### PR DESCRIPTION
Paseo faucet drains too quickly, and 5k PAS is a lot of tokens, which
aren't needed for most operations.
