### PR TITLE
migrate DotNS deployment to bulletin-deploy

### DIFF
--- a/.github/workflows/deploy-dotns.yml
+++ b/.github/workflows/deploy-dotns.yml
@@ -5,11 +5,6 @@ on:
     branches: ["main"]
   pull_request:
   workflow_dispatch:
-    inputs:
-      skip-cache:
-        description: "Force redeploy (skip cache)"
-        type: boolean
-        default: false
 
 concurrency:
   group: dotns-${{ github.event.pull_request.number || github.ref }}
@@ -45,26 +40,64 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  deploy-production:
-    if: github.event_name == 'push'
+  deploy:
     needs: [build-static]
-    uses: paritytech/bulletin-deploy/.github/workflows/deploy.yml@main
-    with:
-      artifact-name: faucet-dotns
-      dotns-domain: faucet.dot
-      skip-cache: ${{ inputs.skip-cache || false }}
-      max-retries: 10
-    secrets:
-      mnemonic: ${{ secrets.DOTNS_MNEMONIC }}
+    runs-on: ubuntu-latest
+    outputs:
+      cid: ${{ steps.deploy.outputs.cid }}
+      domain: ${{ steps.deploy.outputs.domain }}
+      url: ${{ steps.url.outputs.url }}
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@v4
+        with:
+          name: faucet-dotns
+          path: build
+      - name: Install bulletin-deploy CLI
+        run: npm install -g bulletin-deploy
+      - name: Resolve target domain
+        id: domain
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$EVENT" = "pull_request" ]; then
+            echo "domain=faucet-pr${PR_NUM}-preview00.dot" >> "$GITHUB_OUTPUT"
+          else
+            echo "domain=faucet.dot" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Deploy to Bulletin + DotNS
+        id: deploy
+        env:
+          MNEMONIC: ${{ secrets.DOTNS_MNEMONIC }}
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: bulletin-deploy --js-merkle build ${{ steps.domain.outputs.domain }}
+      - name: Compute browser URL
+        id: url
+        env:
+          DOMAIN: ${{ steps.deploy.outputs.domain }}
+        run: echo "url=https://${DOMAIN}.dot.li" >> "$GITHUB_OUTPUT"
+      - name: Deployment summary
+        env:
+          DOMAIN: ${{ steps.deploy.outputs.domain }}
+          CID: ${{ steps.deploy.outputs.cid }}
+          URL: ${{ steps.url.outputs.url }}
+        run: |
+          {
+            echo "### ${DOMAIN}.dot"
+            echo ""
+            echo "Browser &nbsp; ${URL}"
+            echo "Desktop &nbsp; \`${DOMAIN}.dot\`"
+            echo "CID &nbsp; \`${CID}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: bulletin-deploy
+          message: |
+            **${{ steps.deploy.outputs.domain }}.dot** · [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-  deploy-preview:
-    if: github.event_name == 'pull_request'
-    needs: [build-static]
-    uses: paritytech/bulletin-deploy/.github/workflows/deploy.yml@main
-    with:
-      artifact-name: faucet-dotns
-      dotns-domain: faucet-pr${{ github.event.pull_request.number }}-preview00.dot
-      comment-on-pr: true
-      max-retries: 10
-    secrets:
-      mnemonic: ${{ secrets.DOTNS_MNEMONIC }}
+            ${{ steps.url.outputs.url }}

--- a/.github/workflows/deploy-dotns.yml
+++ b/.github/workflows/deploy-dotns.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      skip-cache:
+        description: "Force redeploy (skip cache)"
+        type: boolean
+        default: false
 
 concurrency:
   group: dotns-${{ github.event.pull_request.number || github.ref }}
@@ -42,29 +48,23 @@ jobs:
   deploy-production:
     if: github.event_name == 'push'
     needs: [build-static]
-    uses: paritytech/dotns-sdk/.github/workflows/deploy.yml@main
+    uses: paritytech/bulletin-deploy/.github/workflows/deploy.yml@main
     with:
-      basename: faucet
       artifact-name: faucet-dotns
-      mode: production
-      register-base: true
+      dotns-domain: faucet.dot
+      skip-cache: ${{ inputs.skip-cache || false }}
       max-retries: 10
-      use-car: true
     secrets:
-      dotns-mnemonic: ${{ secrets.DOTNS_MNEMONIC }}
+      mnemonic: ${{ secrets.DOTNS_MNEMONIC }}
 
   deploy-preview:
     if: github.event_name == 'pull_request'
     needs: [build-static]
-    uses: paritytech/dotns-sdk/.github/workflows/deploy.yml@main
+    uses: paritytech/bulletin-deploy/.github/workflows/deploy.yml@main
     with:
-      basename: faucet
       artifact-name: faucet-dotns
-      mode: preview
-      subname-format: pr-number
-      register-base: true
+      dotns-domain: faucet-pr${{ github.event.pull_request.number }}-preview00.dot
+      comment-on-pr: true
       max-retries: 10
-      use-car: true
     secrets:
-      dotns-mnemonic: ${{ secrets.DOTNS_MNEMONIC }}
-      bulletin-mnemonic: "bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice"
+      mnemonic: ${{ secrets.DOTNS_MNEMONIC }}

--- a/.github/workflows/deploy-dotns.yml
+++ b/.github/workflows/deploy-dotns.yml
@@ -12,7 +12,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   build-static:
@@ -92,12 +91,3 @@ jobs:
             echo "Desktop &nbsp; \`${DOMAIN}.dot\`"
             echo "CID &nbsp; \`${CID}\`"
           } >> "$GITHUB_STEP_SUMMARY"
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: bulletin-deploy
-          message: |
-            **${{ steps.deploy.outputs.domain }}.dot** · [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-            ${{ steps.url.outputs.url }}


### PR DESCRIPTION
## Summary

- Replaces `paritytech/dotns-sdk/.github/workflows/deploy.yml` with `paritytech/bulletin-deploy/.github/workflows/deploy.yml` for both production and PR previews.
- Production: deploys to `faucet.dot`.
- Preview: deploys to `faucet-pr<N>-preview00.dot` (trailing `00` avoids the PoP requirement).
- Drops the separate `bulletin-mnemonic` Alice secret — bulletin-deploy uses a single mnemonic for both DotNS registration and chunk submission.
- Adds a `workflow_dispatch` trigger with a `skip-cache` input to force a redeploy when needed.

The build step (yarn install + codegen + Vite static build + artifact upload) is unchanged.