### PR TITLE
summit: point Matrix bot at @summit-faucet-bot:parity.io

### DIFF
--- a/helm/values-parity-testnet-summit.yaml
+++ b/helm/values-parity-testnet-summit.yaml
@@ -7,8 +7,8 @@ substrate-faucet:
       SMF_CONFIG_MATRIX_ACCESS_TOKEN: ref+vault://kv/argo-cd/substrate-faucet/devops-parity-testnet#SUMMIT_MATRIX_ACCESS_TOKEN
     config:
       SMF_CONFIG_NETWORK: 'summit'
-      SMF_CONFIG_MATRIX_SERVER: 'https://matrix.org'
-      SMF_CONFIG_MATRIX_BOT_USER_ID: '@summit-faucet:matrix.org'
+      SMF_CONFIG_MATRIX_SERVER: 'https://m.parity.io'
+      SMF_CONFIG_MATRIX_BOT_USER_ID: '@summit-faucet-bot:parity.io'
       SMF_CONFIG_FAUCET_IGNORE_LIST: ''
     externalAccess: true
   ingress:


### PR DESCRIPTION
## Summary

The Summit faucet bot was provisioned on the Parity homeserver, not matrix.org. Updating the helm config to match.

- `SMF_CONFIG_MATRIX_BOT_USER_ID`: `@summit-faucet:matrix.org` → `@summit-faucet-bot:parity.io`
- `SMF_CONFIG_MATRIX_SERVER`: `https://matrix.org` → `https://m.parity.io` (resolved from `https://parity.io/.well-known/matrix/client`)

Without this, the bot was sending its `SUMMIT_MATRIX_ACCESS_TOKEN` from Vault to `matrix.org`, which doesn't know that token → `M_UNKNOWN_TOKEN` "Token is not active".