### PR TITLE
Add "Make another request" button to web drip success screen

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -177,6 +177,25 @@ div.form-field:focus-within {
   border: 1px solid #44403c;
 }
 
+/* ── Secondary button ── */
+.secondary-btn {
+  @apply btn w-full rounded-xl;
+  height: 2.75rem;
+  margin-top: 0.75rem;
+  background-color: transparent;
+  color: #a8a29e;
+  border: 1px solid #44403c;
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-transform: none;
+  transition: all 0.2s ease;
+}
+
+.secondary-btn:hover {
+  background-color: #292524;
+  color: #fafaf9;
+}
+
 /* ── Dropdown menu ── */
 .dropdown a {
   color: #fafaf9;

--- a/client/src/lib/components/screens/Success.svelte
+++ b/client/src/lib/components/screens/Success.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
-  import { testnet } from "$lib/utils/stores";
+  import { operation, testnet } from "$lib/utils/stores";
 
   import CheckCircle from "../icons/CheckCircle.svelte";
 
   export let blockHash: string | undefined = undefined;
+
+  function onStartOver() {
+    operation.update(() => undefined as never);
+  }
+
+  $: hasExplorerLink = !!($testnet.explorer && blockHash);
 </script>
 
 <div class="icon">
@@ -12,11 +18,18 @@
 <div class="message">
   Successfully sent {$testnet.currency}s to your address.
 </div>
-{#if $testnet.explorer && blockHash}
+{#if hasExplorerLink}
   <a href={`${$testnet.explorer}/${blockHash}`} data-testid="success-button" target="_blank" rel="noreferrer">
     <button class="submit-btn"> See transaction details</button>
   </a>
 {/if}
+<button
+  class={hasExplorerLink ? "secondary-btn" : "submit-btn"}
+  data-testid="start-over"
+  on:click={onStartOver}
+>
+  Make another request
+</button>
 
 <style lang="postcss">
   .message {

--- a/client/src/lib/components/screens/Success.svelte
+++ b/client/src/lib/components/screens/Success.svelte
@@ -23,11 +23,7 @@
     <button class="submit-btn"> See transaction details</button>
   </a>
 {/if}
-<button
-  class={hasExplorerLink ? "secondary-btn" : "submit-btn"}
-  data-testid="start-over"
-  on:click={onStartOver}
->
+<button class={hasExplorerLink ? "secondary-btn" : "submit-btn"} data-testid="start-over" on:click={onStartOver}>
   Make another request
 </button>
 

--- a/client/tests/faucet.ts
+++ b/client/tests/faucet.ts
@@ -330,6 +330,33 @@ export class FaucetTests {
           }
         });
 
+        test("can start over after a successful drip", async ({ page }, { config }) => {
+          await page.goto(this.url);
+          const operationHash = "0x0123435423412343214";
+          const blockHash = "0xblockhash123456789";
+          const { address, captcha, submit } = await getFormElements(page, true);
+          await address.fill("0x000000001");
+          await captcha.click();
+          await page.route(this.getFaucetUrl(config), (route) =>
+            route.fulfill({
+              headers: { "Content-Type": "application/x-ndjson" },
+              body: [
+                JSON.stringify({ status: "included", hash: operationHash, blockHash }),
+                JSON.stringify({ hash: operationHash }),
+              ].join("\n"),
+            }),
+          );
+          await submit.click();
+
+          const startOver = page.getByTestId("start-over");
+          await expect(startOver).toBeVisible();
+          await startOver.click();
+
+          // Back on the form, ready for another request.
+          await expect(page.getByTestId("address")).toBeVisible();
+          await expect(startOver).toHaveCount(0);
+        });
+
         test("throw error", async ({ page }, { config }) => {
           await page.goto(this.url);
           const error = "Things failed because you are a naughty boy!";


### PR DESCRIPTION
## Problem

After a successful drip from the web UI, the success screen showed only the confirmation message (and a transaction link, where available) with **no way back to the form**. Users had to reload the page to make another request.

## Fix

Mirror the existing `Error.svelte` "Go back" pattern: add a **"Make another request"** button to `Success.svelte` that resets the `operation` store to `undefined`, which returns the user to the drip form.

- When a transaction-explorer link is present, the reset renders as a **secondary** button so it doesn't compete with the primary "See transaction details" link.
- When there's no explorer link, it uses the primary `submit-btn` style.
- Added a shared `.secondary-btn` style in `app.css` next to `.submit-btn` (button styles live in global CSS here).

## Testing

- Added a Playwright test verifying the button appears after a successful drip and clicking it returns to a usable form.
- Existing "display link to transaction" test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)