### PR TITLE
Expose Asset Hub's real chain id instead of the -1 sentinel

### DIFF
--- a/client/src/lib/components/Form.svelte
+++ b/client/src/lib/components/Form.svelte
@@ -73,9 +73,9 @@
   };
 
   let balance: { transferable: string; reserved: string; overCap: boolean } | null = null;
-  // Balance is only meaningful when the drip lands on the faucet's source chain (Hub, network === -1).
+  // Balance is only meaningful when the drip lands on the faucet's home chain (Asset Hub).
   // For teleport destinations, the faucet's RPC can't see the user's balance there.
-  $: balanceApplies = network === -1;
+  $: balanceApplies = network === networkData.hubChainId;
   $: overCap = balanceApplies && (balance?.overCap ?? false);
   let balanceLoading = false;
   let debounceTimer: ReturnType<typeof setTimeout>;

--- a/client/src/lib/components/NetworkInput.svelte
+++ b/client/src/lib/components/NetworkInput.svelte
@@ -33,11 +33,7 @@
       elem?.blur();
     }
     network = chain;
-    if (chain === -1) {
-      $page.url.searchParams.delete("parachain");
-    } else {
-      $page.url.searchParams.set("parachain", chain.toString());
-    }
+    $page.url.searchParams.set("parachain", chain.toString());
 
     goto(`?${$page.url.searchParams.toString()}`);
   }

--- a/client/src/lib/utils/faucetRequest.ts
+++ b/client/src/lib/utils/faucetRequest.ts
@@ -26,7 +26,7 @@ export async function request(
   if (DEMO !== undefined && DEMO !== "") {
     return await boilerplateRequest(address, onStatus);
   }
-  const chain = parachain !== undefined && parachain >= 0 ? parachain.toString() : undefined;
+  const chain = parachain !== undefined ? parachain.toString() : undefined;
   return await faucetRequest(address, auth, network, chain, onStatus);
 }
 

--- a/client/src/lib/utils/networkData.ts
+++ b/client/src/lib/utils/networkData.ts
@@ -30,6 +30,8 @@ export interface NetworkData {
   currency: string;
   dripAmount: string;
   chains: ChainData[];
+  /** Para id of the faucet's home chain (Asset Hub). A drip to this id is a local transfer, not a teleport. */
+  hubChainId: number;
   endpoint: string;
   explorer: string | null;
   teleportEnabled: boolean;
@@ -45,8 +47,9 @@ export const Westend: NetworkData = {
   networkName: "Westend",
   currency: "WND",
   dripAmount: "10",
+  hubChainId: 1000,
   chains: [
-    { name: "Hub (smart contracts)", id: -1 },
+    { name: "Asset Hub", id: 1000 },
     { name: "Westend Relay", id: 0 },
     { name: "Collectives", id: 1001 },
     { name: "BridgeHub", id: 1002 },
@@ -68,8 +71,9 @@ export const Paseo: NetworkData = {
   networkName: "Paseo",
   currency: "PAS",
   dripAmount: "5000",
+  hubChainId: 1000,
   chains: [
-    { name: "Hub (smart contracts)", id: -1 },
+    { name: "Asset Hub", id: 1000 },
     { name: "Paseo Relay", id: 0 },
     { name: "BridgeHub", id: 1002 },
     { name: "People", id: 1004 },
@@ -92,6 +96,7 @@ export const Summit: NetworkData = {
   networkName: "Summit",
   currency: "SUM",
   dripAmount: "5000",
+  hubChainId: 1500,
   chains: [
     { name: "Asset Hub", id: 1500 },
     { name: "Summit Relay", id: 0 },

--- a/client/tests/faucet.ts
+++ b/client/tests/faucet.ts
@@ -108,7 +108,7 @@ export class FaucetTests {
           test("page loads with default value in parachain field", async ({ page }) => {
             await page.goto(this.url);
             const { network } = await getFormElements(page);
-            await expect(network).toHaveValue("-1");
+            await expect(network).toHaveValue(String(this.chains[0].id));
           });
 
           test("page with get parameter loads with value in parachain field", async ({ page }) => {
@@ -194,10 +194,10 @@ export class FaucetTests {
             await expect(network).toHaveValue("");
           });
 
-          test("Value restores to -1 when picking preselected network", async () => {
+          test("Value restores to the default chain id when picking preselected network", async () => {
             await customChainDiv.click();
             await expect(network).toBeHidden();
-            await expect(network).toHaveValue("-1");
+            await expect(network).toHaveValue(String(this.chains[0].id));
           });
         });
       }
@@ -237,7 +237,7 @@ export class FaucetTests {
         });
 
         if (this.teleportEnabled) {
-          for (let i = 1; i < this.chains.length; i++) {
+          for (let i = 0; i < this.chains.length; i++) {
             const chain = this.chains[i];
             test(`sends data with ${chain.name} chain on submit`, async ({ page }, { config }) => {
               await page.goto(this.url);
@@ -258,12 +258,7 @@ export class FaucetTests {
               const request = page.waitForRequest((req) => {
                 if (req.url() === faucetUrl) {
                   const data = req.postDataJSON() as FormSubmit;
-                  if (chain.id == -1) {
-                    expect(data).toMatchObject({ address: myAddress });
-                  } else {
-                    const parachain_id = chain.id >= 0 ? chain.id.toString() : undefined;
-                    expect(data).toMatchObject({ address: myAddress, parachain_id });
-                  }
+                  expect(data).toMatchObject({ address: myAddress, parachain_id: chain.id.toString() });
                   return !!data.recaptcha;
                 }
                 return false;

--- a/client/tests/paseo.test.ts
+++ b/client/tests/paseo.test.ts
@@ -1,7 +1,7 @@
 import { FaucetTests } from "./faucet.js";
 
 const chains = [
-  { name: "Hub (smart contracts)", id: -1 },
+  { name: "Asset Hub", id: 1000 },
   { name: "Paseo Relay", id: 0 },
   { name: "BridgeHub", id: 1002 },
   { name: "People", id: 1004 },

--- a/client/tests/westend.test.ts
+++ b/client/tests/westend.test.ts
@@ -1,7 +1,7 @@
 import { FaucetTests } from "./faucet.js";
 
 const chains = [
-  { name: "Hub (smart contracts)", id: -1 },
+  { name: "Asset Hub", id: 1000 },
   { name: "Westend Relay", id: 0 },
   { name: "Collectives", id: 1001 },
   { name: "BridgeHub", id: 1002 },


### PR DESCRIPTION
## Problem

The chain dropdown used a magic id of **`-1`** for "Hub (smart contracts)". The client translated `-1` into "send no `parachain_id`", which made the server perform a local transfer on its home chain (Asset Hub). This leaked an internal sentinel into the user-facing UI and made the `?parachain=` URL story inconsistent — users had to know about `-1`, which isn't a real chain id.

The cleaner model: **the user picks the real destination chain id, and if it happens to match the faucet's source chain, the faucet just does a local transfer.**

## Why no backend change is needed

The server already does exactly this. In `PolkadotActions.sendTokens`:

```ts
if (parachain_id === networkData.data.id) {   // source chain id
  result = await this.transferTokens(...)       // local transfer, no teleport
} else if (teleportEnabled) {
  result = await this.teleportTokens(...)
}
```

`networkData.data.id` is **1000** for Paseo/Westend. So sending `parachain_id=1000` produces the identical local transfer that `-1` did. **Summit already relies on this** — it lists its Asset Hub with the real id `1500`, no sentinel.

## 🐞 Bonus bug fix: Summit's balance/cap preview is currently broken

This is worth calling out explicitly. The balance + over-cap preview in `Form.svelte` was gated on `network === -1`:

- On Paseo/Westend it worked, because the Hub option was `-1`.
- **On Summit it never fired** — Summit's Asset Hub is `1500`, which never equals `-1`. So Summit users get **no transferable/reserved balance display and no client-side over-cap warning today.**

By re-keying that check to a per-network `hubChainId` (`1000`/`1000`/`1500`), this PR fixes Summit as a side effect of removing the sentinel.

## Changes (client only)

- **`networkData.ts`** — relabel the entry to **"Asset Hub"** with its real id (`1000` on Paseo/Westend); add a `hubChainId` field per network (Paseo/Westend `1000`, Summit `1500`).
- **`Form.svelte`** — key the balance/cap preview off `hubChainId` instead of `=== -1` (this is the Summit fix above).
- **`faucetRequest.ts`** — drop the `>= 0` gate; always forward the selected id.
- **`NetworkInput.svelte`** — selecting Asset Hub now sets `?parachain=1000` like any other chain, instead of clearing the param.
- **tests** — assert Asset Hub submits `parachain_id=1000`; extend the per-chain submit loop to cover index 0; update fixtures and the "restores to default" assertion.

## Testing

Full client Playwright suite passes (67/67), incl. new coverage that Asset Hub submits `parachain_id=1000`. `svelte-check` clean.

## Stack / merge order

Branches off `main`. **#521 is stacked on top of this branch** (its FAQ + chain-id hint depend on the real Asset Hub id). Merge order: **this PR first, then #521.** 

🤖 Generated with [Claude Code](https://claude.com/claude-code)