### PR TITLE
Move custom chain id into the dropdown as a "Custom chain ID…" option

### DIFF
--- a/client/src/lib/components/NetworkInput.svelte
+++ b/client/src/lib/components/NetworkInput.svelte
@@ -11,9 +11,7 @@
   let input: HTMLInputElement;
 
   let customValue: boolean = false;
-  let customBtnMessage = "Use preselected chains";
 
-  $: customBtnMessage = !customValue ? "Use custom chain id" : "Use preselected chains";
   $: customValue = !getChainName($testnet, network);
 
   function switchCustomValue() {
@@ -68,17 +66,19 @@
             <a on:click={() => selectChain(chain.id)}>{chain.name}</a>
           </li>
         {/each}
+        <li class="custom-option" data-testid="custom-network-button">
+          <a on:click={switchCustomValue}>Custom chain ID…</a>
+        </li>
       </ul>
     </div>
-  {/if}
-  <div class="switch-row">
-    <div class="custom-chain-switch" on:click={switchCustomValue} data-testid="custom-network-button">
-      &#8594; {customBtnMessage}
-    </div>
-    {#if !customValue && network >= 0}
-      <span class="chain-id-hint" data-testid="chain-id-hint">Chain ID: {network}</span>
+    {#if network >= 0}
+      <div class="chain-id-hint" data-testid="chain-id-hint">Chain ID: {network}</div>
     {/if}
-  </div>
+  {:else}
+    <div class="custom-chain-switch" on:click={switchCustomValue} data-testid="preset-chains-button">
+      &#8592; Use a preset chain
+    </div>
+  {/if}
 </div>
 
 <style lang="postcss">
@@ -86,21 +86,25 @@
     margin-bottom: 1rem;
   }
 
-  .switch-row {
-    @apply flex items-center justify-between;
-    margin-top: 0.375rem;
-  }
-
   .custom-chain-switch {
     @apply text-left hover:underline hover:cursor-pointer;
     color: #ff2867;
     font-weight: 400;
     font-size: 0.813rem;
+    margin-top: 0.375rem;
   }
 
   .chain-id-hint {
+    @apply text-left;
+    margin-top: 0.375rem;
     font-size: 0.813rem;
     color: #78716c;
+  }
+
+  .custom-option {
+    border-top: 1px solid #44403c;
+    margin-top: 0.25rem;
+    padding-top: 0.25rem;
   }
 
   /* Chrome, Safari, Edge, Opera */

--- a/client/tests/faucet.ts
+++ b/client/tests/faucet.ts
@@ -196,9 +196,10 @@ export class FaucetTests {
           test.beforeEach(async ({ page }) => {
             await page.goto(this.url);
             network = (await getFormElements(page)).network;
+            // The custom-chain option lives inside the dropdown; open it first.
+            await page.getByTestId("dropdown").click();
             customChainDiv = page.getByTestId("custom-network-button");
-            await expect(customChainDiv).toBeEnabled();
-            await expect(customChainDiv).toContainText("Use custom chain id");
+            await expect(customChainDiv).toContainText("Custom chain ID");
             await customChainDiv.click();
             await expect(network).toBeVisible();
           });
@@ -207,8 +208,8 @@ export class FaucetTests {
             await expect(network).toHaveValue("");
           });
 
-          test("Value restores to the default chain id when picking preselected network", async () => {
-            await customChainDiv.click();
+          test("Value restores to the default chain id when picking preselected network", async ({ page }) => {
+            await page.getByTestId("preset-chains-button").click();
             await expect(network).toBeHidden();
             await expect(network).toHaveValue(String(this.chains[0].id));
           });
@@ -288,6 +289,7 @@ export class FaucetTests {
             await expect(submit).toBeDisabled();
             const myAddress = "0x000000002";
             await address.fill(myAddress);
+            await page.getByTestId("dropdown").click();
             const customChainDiv = page.getByTestId("custom-network-button");
             await customChainDiv.click();
             await network.fill("9999");


### PR DESCRIPTION
> Rebased onto `main` now that #520/#521/#522 have merged. Diff is just `NetworkInput.svelte` + its tests.

## What

Replaces the standalone **"→ Use custom chain id"** toggle link with a **"Custom chain ID…"** entry at the bottom of the Chain dropdown. Selecting it reveals the number input; a **"← Use a preset chain"** link returns to the list.

This is the conventional "preset options + custom value" pattern: a single entry point (the dropdown the user is already in) with the custom path as a clearly-separated last item, instead of an orphan link that reads like navigation.

## Before / after

- **Before:** dropdown of chains, plus a separate pink `→ Use custom chain id` link below it that swapped the control for an input.
- **After:** dropdown of chains **+ a `Custom chain ID…` item** (divider-separated). Custom mode shows the input and a `← Use a preset chain` link back. The `Chain ID: <n>` hint sits directly under the dropdown in preset mode.

## Changes

- **`NetworkInput.svelte`** — the dropdown's list gains the custom option (`data-testid=custom-network-button`); custom mode renders the input plus a back link (`data-testid=preset-chains-button`). Removed the now-unused toggle-label state.
- **tests** — open the dropdown before choosing the custom option; return to presets via the new back link.

## Testing

Affected Playwright tests pass (dropdown interaction, Custom networks, custom-chain submit, chain-id hint — 8/8 across both networks after rebase). `svelte-check`, ESLint, and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)